### PR TITLE
Definitive action for updating API version

### DIFF
--- a/.github/workflows/update_api_version.yml
+++ b/.github/workflows/update_api_version.yml
@@ -2,7 +2,7 @@ name: update api version
 
 on:
   pull_request:
-    branches: ['main', 'api-version']
+    branches: ['*']
 
 jobs:
   updateapiversion:

--- a/.github/workflows/update_api_version.yml
+++ b/.github/workflows/update_api_version.yml
@@ -1,8 +1,8 @@
 name: update api version
 
 on:
-  pull_request:
-    branches: ['*']
+  push:
+    branches: ['*', '!main']
 
 jobs:
   updateapiversion:

--- a/beacon/conf/api_version.yml
+++ b/beacon/conf/api_version.yml
@@ -1,1 +1,1 @@
-api_version: v2.0-164671f
+api_version: v2.0-154384d


### PR DESCRIPTION
This PR addresses the way API version is updated as now all branches will trigger the action on push except for main, solving the action failing when PRs are made to main (exception of not being in any branch while triggering the push in a PR).