### PR TITLE
Bugfix/missing filtering terms

### DIFF
--- a/beacon/connections/mongo/extract_filtering_terms.py
+++ b/beacon/connections/mongo/extract_filtering_terms.py
@@ -127,8 +127,8 @@ def get_ontology_field_name(ontology_id:str, term_id:str, collection:str):
                                     if v2 == ontology_id + ':' + term_id:
                                         field = k + '.' + k2
                                         for key, value in item.items():
-                                            if k == 'label':
-                                                label = v
+                                            if key == 'label':
+                                                label = value.lower()
                                                 break
                                         break
                                 elif isinstance(v2, dict):

--- a/beacon/connections/mongo/extract_filtering_terms.py
+++ b/beacon/connections/mongo/extract_filtering_terms.py
@@ -259,8 +259,7 @@ def get_filtering_object(terms_ids: list, collection_name: str):
             value_id=None
             if 'measurements.assayCode' in field:
                 value_id = label
-            else:
-                ontology_label = label
+            ontology_label = label
             if field is not None:
                 if onto not in list_of_ontologies:
                     list_of_ontologies.append(onto)


### PR DESCRIPTION
In this PR we propose a fix for issues that we encountered when we loaded data to our beacon2-pi instance:
- extract_filtering_terms.py skipped filtering terms that are stored in an array of object in MongoDB
- extract_filtering_terms.py assigned duplicated/incorrect labels to filtering terms when field=='measurements.assayCode'