### PR TITLE
fix beacon config loading

### DIFF
--- a/beacon/conf/conf_override.py
+++ b/beacon/conf/conf_override.py
@@ -1,7 +1,9 @@
-import beacon.conf.conf as _defaults
+import beacon.conf.conf_default as _defaults
+
 
 class Config:
     pass
+
 
 config = Config()
 
@@ -12,9 +14,11 @@ for key in dir(_defaults):
 
 # Override with user config if present
 try:
-    import beacon.conf.conf_default as _userconf
+    import beacon.conf.conf as _userconf
+
     for key in dir(_userconf):
         if not key.startswith("_"):
             setattr(config, key, getattr(_userconf, key))
-except ImportError:
+except ImportError as e:
+    print(f"failed to load: {e}")
     pass


### PR DESCRIPTION
The current implementation of the config loading is inverse of the comments and also does not set user configuration correctly since it first loads the user config and then overrides the values with the values from the `conf_default.py`.

This implementation first loads all the default values from `conf_default.py` and then overrides the values with the values from `conf.py` that is defined by the user.

This implementaton will also print out the occured error when an `importError` occurs, this gives the user more information as to which specific configuration causes an issue which improves debugging, while still respecting the behavior of just passing over `importError`s